### PR TITLE
Feature/6 공용 페이지네이션 유틸 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "#docs/*": "./src/docs/*",
     "#repositories": "./src/repositories/index.js",
     "#constants": "./src/common/constants/index.js",
+    "#utils": "./src/common/utils/index.js",
+    "#utils/*": "./src/common/utils/*",
     "#exceptions": "./src/common/exceptions/index.js",
     "#controllers": "./src/controllers/index.js",
     "#controllers/*": "./src/controllers/*",

--- a/prisma/seed.constants.js
+++ b/prisma/seed.constants.js
@@ -3,22 +3,22 @@ export const DAY_IN_MS = 24 * 60 * 60 * 1000;
 // 시드 생성 개수
 export const SEED_PASSWORD = 'Test1234!'; // 시드용 공통 비밀번호 (개발 환경 전용)
 
-export const USERS_COUNT = 10;
+export const USERS_COUNT = 40;
 export const NICKNAME_MAX_LENGTH = 20;
 
-export const CHALLENGES_COUNT = 13;
+export const CHALLENGES_COUNT = 100;
 export const CHALLENGE_DEADLINE = 30;
-export const CHALLENGE_MIN_PARTICIPANTS = 3;
-export const CHALLENGE_MAX_PARTICIPANTS = 10;
+export const CHALLENGE_MIN_PARTICIPANTS = 5;
+export const CHALLENGE_MAX_PARTICIPANTS = 15;
 
-export const APPLICANTS_MIN = 2;
-export const APPLICANTS_MAX = 8;
+export const APPLICANTS_MIN = 5;
+export const APPLICANTS_MAX = 20;
 
-export const COMMENTERS_TAKE = 3;
-export const LIKERS_TAKE = 5;
+export const COMMENTERS_TAKE = 5;
+export const LIKERS_TAKE = 10;
 
-export const NOTIFICATIONS_PER_USER_MIN = 1;
-export const NOTIFICATIONS_PER_USER_MAX = 5;
+export const NOTIFICATIONS_PER_USER_MIN = 3;
+export const NOTIFICATIONS_PER_USER_MAX = 10;
 
 export const NOTIFICATION_RECENT_DAYS = 14;
 

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -67,7 +67,8 @@ class Seeder {
 
     for (let i = 0; i < this.#numUsersToCreate; i += 1) {
       const email = faker.internet.email();
-      const nickname = faker.person.firstName();
+      const baseNickname = faker.person.firstName();
+      const nickname = `${baseNickname}_${i + 1}`;
 
       const user = await this.#prisma.user.create({
         data: {

--- a/src/common/utils/cursor-pagination.js
+++ b/src/common/utils/cursor-pagination.js
@@ -1,6 +1,15 @@
 const DEFAULT_CURSOR_LIMIT = 20;
 const MAX_CURSOR_LIMIT = 100;
 
+function normalizeLimit(value, maxLimit = MAX_CURSOR_LIMIT) {
+  const safeMaxLimit = Math.max(1, Number(maxLimit) || MAX_CURSOR_LIMIT);
+
+  return Math.min(
+    safeMaxLimit,
+    Math.max(1, Number(value) || DEFAULT_CURSOR_LIMIT),
+  );
+}
+
 // Prisma findMany에 넣을 cursor/skip/take 계산
 export function getCursorParams({
   cursor,
@@ -8,16 +17,13 @@ export function getCursorParams({
   maxLimit = MAX_CURSOR_LIMIT,
   cursorKey = 'id',
 } = {}) {
-  const resolvedLimit = Math.min(
-    maxLimit,
-    Math.max(1, Number(limit) || DEFAULT_CURSOR_LIMIT),
-  );
-
-  const hasCursor = cursor != null && String(cursor).trim() !== '';
+  const resolvedLimit = normalizeLimit(limit, maxLimit);
+  const trimmedCursor = cursor == null ? '' : String(cursor).trim();
+  const hasCursor = trimmedCursor !== '';
 
   return {
     ...(hasCursor && {
-      cursor: { [cursorKey]: String(cursor).trim() },
+      cursor: { [cursorKey]: trimmedCursor },
       skip: 1,
     }),
     take: resolvedLimit + 1,
@@ -28,21 +34,19 @@ export function getCursorParams({
 // findMany 결과에서 다음 커서와 잘린 목록 추출
 export function parseCursorResult({
   items,
-  requestedLimit,
+  limit = DEFAULT_CURSOR_LIMIT,
+  maxLimit = MAX_CURSOR_LIMIT,
   cursorKey = 'id',
 } = {}) {
   const list = Array.isArray(items) ? items : [];
-  const limit = Math.min(
-    MAX_CURSOR_LIMIT,
-    Math.max(1, Number(requestedLimit) || DEFAULT_CURSOR_LIMIT),
-  );
+  const resolvedLimit = normalizeLimit(limit, maxLimit);
 
-  const hasNext = list.length > limit;
-  const resultItems = hasNext ? list.slice(0, limit) : list;
-
+  const hasNext = list.length > resolvedLimit;
+  const resultItems = hasNext ? list.slice(0, resolvedLimit) : list;
   const lastItem = resultItems[resultItems.length - 1];
+
   const nextCursor =
-    hasNext && lastItem && typeof lastItem === 'object' && cursorKey in lastItem
+    hasNext && lastItem?.[cursorKey] != null
       ? String(lastItem[cursorKey])
       : null;
 

--- a/src/common/utils/cursor-pagination.js
+++ b/src/common/utils/cursor-pagination.js
@@ -1,0 +1,54 @@
+const DEFAULT_CURSOR_LIMIT = 20;
+const MAX_CURSOR_LIMIT = 100;
+
+// Prisma findMany에 넣을 cursor/skip/take 계산
+export function getCursorParams({
+  cursor,
+  limit = DEFAULT_CURSOR_LIMIT,
+  maxLimit = MAX_CURSOR_LIMIT,
+  cursorKey = 'id',
+} = {}) {
+  const resolvedLimit = Math.min(
+    maxLimit,
+    Math.max(1, Number(limit) || DEFAULT_CURSOR_LIMIT),
+  );
+
+  const hasCursor = cursor != null && String(cursor).trim() !== '';
+
+  return {
+    ...(hasCursor && {
+      cursor: { [cursorKey]: String(cursor).trim() },
+      skip: 1,
+    }),
+    take: resolvedLimit + 1,
+    limit: resolvedLimit,
+  };
+}
+
+// findMany 결과에서 다음 커서와 잘린 목록 추출
+export function parseCursorResult({
+  items,
+  requestedLimit,
+  cursorKey = 'id',
+} = {}) {
+  const list = Array.isArray(items) ? items : [];
+  const limit = Math.min(
+    MAX_CURSOR_LIMIT,
+    Math.max(1, Number(requestedLimit) || DEFAULT_CURSOR_LIMIT),
+  );
+
+  const hasNext = list.length > limit;
+  const resultItems = hasNext ? list.slice(0, limit) : list;
+
+  const lastItem = resultItems[resultItems.length - 1];
+  const nextCursor =
+    hasNext && lastItem && typeof lastItem === 'object' && cursorKey in lastItem
+      ? String(lastItem[cursorKey])
+      : null;
+
+  return {
+    items: resultItems,
+    nextCursor,
+    hasNext,
+  };
+}

--- a/src/common/utils/cursor-pagination.js
+++ b/src/common/utils/cursor-pagination.js
@@ -1,6 +1,7 @@
 const DEFAULT_CURSOR_LIMIT = 20;
 const MAX_CURSOR_LIMIT = 100;
 
+// 쿼리 정규화
 function normalizeLimit(value, maxLimit = MAX_CURSOR_LIMIT) {
   const safeMaxLimit = Math.max(1, Number(maxLimit) || MAX_CURSOR_LIMIT);
 

--- a/src/common/utils/index.js
+++ b/src/common/utils/index.js
@@ -1,0 +1,3 @@
+export { getOffsetParams, getOffsetMeta } from './offset-pagination.js';
+
+export { getCursorParams, parseCursorResult } from './cursor-pagination.js';

--- a/src/common/utils/offset-pagination.js
+++ b/src/common/utils/offset-pagination.js
@@ -1,0 +1,49 @@
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 100;
+
+function normalizePage(value) {
+  return Math.max(1, Number(value) || 1);
+}
+
+function normalizePageSize(value, maxPageSize = MAX_PAGE_SIZE) {
+  const safeMaxPageSize = Math.max(1, Number(maxPageSize) || MAX_PAGE_SIZE);
+
+  return Math.min(
+    safeMaxPageSize,
+    Math.max(1, Number(value) || DEFAULT_PAGE_SIZE),
+  );
+}
+
+// Prisma findMany에 넣을 skip/take 계산
+export function getOffsetParams({
+  page = 1,
+  pageSize = DEFAULT_PAGE_SIZE,
+  maxPageSize = MAX_PAGE_SIZE,
+} = {}) {
+  const currentPage = normalizePage(page);
+  const size = normalizePageSize(pageSize, maxPageSize);
+
+  return {
+    skip: (currentPage - 1) * size,
+    take: size,
+    page: currentPage,
+    pageSize: size,
+  };
+}
+
+// 전체 개수 기반 응답 메타 정보 계산
+export function getOffsetMeta({ totalCount, page, pageSize }) {
+  const total = Math.max(0, Number(totalCount) || 0);
+  const currentPage = normalizePage(page);
+  const size = normalizePageSize(pageSize);
+  const totalPages = Math.ceil(total / size);
+
+  return {
+    totalCount: total,
+    totalPages,
+    currentPage,
+    pageSize: size,
+    hasNextPage: currentPage < totalPages,
+    hasPreviousPage: currentPage > 1,
+  };
+}

--- a/src/common/utils/offset-pagination.js
+++ b/src/common/utils/offset-pagination.js
@@ -1,6 +1,7 @@
 const DEFAULT_PAGE_SIZE = 10;
 const MAX_PAGE_SIZE = 100;
 
+// 쿼리 정규화
 function normalizePage(value) {
   return Math.max(1, Number(value) || 1);
 }
@@ -31,7 +32,6 @@ export function getOffsetParams({
   };
 }
 
-// 전체 개수 기반 응답 메타 정보 계산
 export function getOffsetMeta({ totalCount, page, pageSize }) {
   const total = Math.max(0, Number(totalCount) || 0);
   const currentPage = normalizePage(page);

--- a/src/controllers/challenges/challenge.controller.js
+++ b/src/controllers/challenges/challenge.controller.js
@@ -16,10 +16,7 @@ export class ChallengesController extends BaseController {
   }
 
   routes() {
-    this.router.get('/me', needsLogin, (req, res) =>
-      this.getMyChallenges(req, res),
-    );
-
+    // 전체 목록 조회 (커서 기반 페이지네이션)
     this.router.get('/', (req, res) => this.findAll(req, res));
 
     this.router.get(
@@ -50,17 +47,12 @@ export class ChallengesController extends BaseController {
       (req, res) => this.delete(req, res),
     );
 
+    this.router.get('/me', needsLogin, (req, res) =>
+      this.getMyChallenges(req, res),
+    );
+
     return this.router;
   }
-
-  // GET	/challenges	전체 챌린지 목록 조회(필터링, 페이징 적용 가능)
-  // GET	/challenges/:id	특정 챌린지 상세 조회(ULID사용)
-  // POST	/challenges	새로운 챌린지 생성
-  // PATCH	/challenges/:id	특정 챌린지 정보 수정(제목, 설명, 상태 등 부분 수정)
-  // DELETE	/challenges/:id	특정 챌린지 삭제
-  // GET	/challenges/me	내가 만든 챌린지 조회
-
-  // res <- controller req <-> service <-> repository <-> DB
 
   async findAll(req, res) {
     const challenges = await this.#challengesService.listChallenges(req.query);
@@ -109,7 +101,7 @@ export class ChallengesController extends BaseController {
     const userId = req.user.id;
 
     const myChallenges =
-      await this.#challengesService.getChallengesByUser(userId); //challenge.service.js에 없는데, 일단 넣어둠
+      await this.#challengesService.getChallengesByUser(userId);
     res.status(HTTP_STATUS.OK).json(myChallenges);
   }
 }

--- a/src/controllers/challenges/dto/challenge.dto.js
+++ b/src/controllers/challenges/dto/challenge.dto.js
@@ -10,15 +10,24 @@ export const ulidSchema = z.ulid({
   message: `유효한 id 형식(ULID)이 아닙니다.`,
 });
 
-// GET /challenges
-// 페이지네이션 쿼리 확정해서 수정 필요
+// 커서 기반 페이지네이션
 export const listChallengesQuerySchema = z.object({
-  page: z.string().optional(),
-  limit: z.string().optional(),
-  type: z.enum(Type).optional(),
-  category: z.enum(Category).optional(),
-  status: z.enum(ChallengeStatus).optional(),
-  isClosed: z.string().optional(),
+  cursor: z
+    .ulid()
+    .optional()
+    .describe('다음 페이지를 위한 커서(ULID). 없으면 첫 페이지 조회'),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(20)
+    .describe('한 번에 조회할 최대 개수'),
+  type: z.enum(Type).optional().describe('챌린지 타입 필터'),
+  category: z.enum(Category).optional().describe('카테고리 필터'),
+  status: z.enum(ChallengeStatus).optional().describe('상태 필터'),
+  keyword: z.string().optional().describe('제목/설명 검색 키워드'),
 });
 
 export const challengeIdParamSchema = z.object({

--- a/src/controllers/challenges/dto/challenge.dto.js
+++ b/src/controllers/challenges/dto/challenge.dto.js
@@ -5,6 +5,8 @@ const DESCRIPTION_MIN_LENGTH = 10;
 const DESCRIPTION_MAX_LIMIT = 500;
 const TITLE_MAX_LENGTH = 100;
 const REASON_MAX_LIMIT = 255;
+const PAGE_SIZE_DEFAULT = 20;
+const PAGE_SIZE_MAX = 100;
 
 export const ulidSchema = z.ulid({
   message: `유효한 id 형식(ULID)이 아닙니다.`,
@@ -15,19 +17,23 @@ export const listChallengesQuerySchema = z.object({
   cursor: z
     .ulid()
     .optional()
-    .describe('다음 페이지를 위한 커서(ULID). 없으면 첫 페이지 조회'),
+    .describe('다음 페이지를 위한 커서(없으면 첫 페이지 조회)'),
   limit: z.coerce
     .number()
     .int()
-    .min(1)
-    .max(100)
-    .optional()
-    .default(20)
+    .min(1, { error: 'limit은 1 이상이어야 합니다.' })
+    .max(PAGE_SIZE_MAX, { error: `limit은 ${PAGE_SIZE_MAX}이하여야 합니다.` })
+    .default(PAGE_SIZE_DEFAULT)
     .describe('한 번에 조회할 최대 개수'),
   type: z.enum(Type).optional().describe('챌린지 타입 필터'),
   category: z.enum(Category).optional().describe('카테고리 필터'),
   status: z.enum(ChallengeStatus).optional().describe('상태 필터'),
-  keyword: z.string().optional().describe('제목/설명 검색 키워드'),
+  keyword: z
+    .string()
+    .trim()
+    .min(1, { error: 'keyword는 비어 있을 수 없습니다.' })
+    .optional()
+    .describe('제목/설명 검색 키워드'),
 });
 
 export const challengeIdParamSchema = z.object({

--- a/src/docs/openapi.js
+++ b/src/docs/openapi.js
@@ -2,6 +2,11 @@ import { z } from 'zod';
 import { createDocument } from 'zod-openapi';
 import { signupSchema, loginSchema } from '#controllers/auth/dto/auth.dto.js';
 import { updateUserSchema } from '#controllers/users/dto/user.dto.js';
+import {
+  listChallengesQuerySchema,
+  createChallengeSchema,
+} from '#controllers/challenges/dto/challenge.dto.js';
+import { ERROR_MESSAGE } from '#constants';
 
 const idParamSchema = z.object({
   id: z.string().describe('사용자 ID'),
@@ -52,6 +57,32 @@ const userIdPathSchema = idParamSchema.meta({
   id: 'UserIdPath',
 });
 
+const challengeSummarySchema = createChallengeSchema
+  .extend({
+    id: z.string().describe('챌린지 ID (ULID)'),
+    authorId: z.string().describe('작성자 ID'),
+    createdAt: z.string().describe('생성 시각 (ISO8601)'),
+    updatedAt: z.string().describe('수정 시각 (ISO8601)'),
+  })
+  .partial({
+    declineReason: true,
+  })
+  .meta({
+    id: 'ChallengeSummary',
+    description: '챌린지 목록용 요약 정보',
+  });
+
+const challengeListResponseSchema = z
+  .object({
+    challenges: z.array(challengeSummarySchema),
+    nextCursor: z.string().nullable().describe('다음 페이지 조회용 커서'),
+    hasNext: z.boolean().describe('다음 페이지 존재 여부'),
+  })
+  .meta({
+    id: 'ChallengeListResponse',
+    description: '커서 기반 챌린지 목록 응답',
+  });
+
 export const openApiDocument = createDocument({
   openapi: '3.1.0',
   info: {
@@ -72,6 +103,10 @@ export const openApiDocument = createDocument({
     {
       name: 'Users',
       description: '사용자 관리 API',
+    },
+    {
+      name: 'Challenges',
+      description: '챌린지 조회/생성 API',
     },
   ],
   components: {
@@ -127,6 +162,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  ValidationError: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.VALIDATION_FAILED,
+                    },
+                  },
+                },
               },
             },
           },
@@ -135,6 +178,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  EmailConflict: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.EMAIL_ALREADY_EXISTS,
+                    },
+                  },
+                },
               },
             },
           },
@@ -167,6 +218,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  ValidationError: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.VALIDATION_FAILED,
+                    },
+                  },
+                },
               },
             },
           },
@@ -175,6 +234,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  Unauthorized: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.INVALID_LOGIN,
+                    },
+                  },
+                },
               },
             },
           },
@@ -211,6 +278,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  Unauthorized: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.UNAUTHORIZED,
+                    },
+                  },
+                },
               },
             },
           },
@@ -254,6 +329,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  NotFound: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.USER_NOT_FOUND,
+                    },
+                  },
+                },
               },
             },
           },
@@ -288,6 +371,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  ValidationError: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.VALIDATION_FAILED,
+                    },
+                  },
+                },
               },
             },
           },
@@ -296,6 +387,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  Unauthorized: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.UNAUTHORIZED,
+                    },
+                  },
+                },
               },
             },
           },
@@ -304,6 +403,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  Forbidden: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.FORBIDDEN,
+                    },
+                  },
+                },
               },
             },
           },
@@ -312,6 +419,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  NotFound: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.USER_NOT_FOUND,
+                    },
+                  },
+                },
               },
             },
           },
@@ -333,6 +448,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  Unauthorized: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.UNAUTHORIZED,
+                    },
+                  },
+                },
               },
             },
           },
@@ -341,6 +464,14 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  Forbidden: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.FORBIDDEN,
+                    },
+                  },
+                },
               },
             },
           },
@@ -349,6 +480,49 @@ export const openApiDocument = createDocument({
             content: {
               'application/json': {
                 schema: errorResponseSchema,
+                examples: {
+                  NotFound: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.USER_NOT_FOUND,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/challenges': {
+      get: {
+        tags: ['Challenges'],
+        summary: '챌린지 목록 조회 (커서 기반 페이지네이션)',
+        requestParams: {
+          query: listChallengesQuerySchema,
+        },
+        responses: {
+          200: {
+            description: '챌린지 목록 조회 성공',
+            content: {
+              'application/json': {
+                schema: challengeListResponseSchema,
+              },
+            },
+          },
+          400: {
+            description: '입력값 검증 실패',
+            content: {
+              'application/json': {
+                schema: errorResponseSchema,
+                examples: {
+                  ValidationError: {
+                    value: {
+                      success: false,
+                      message: ERROR_MESSAGE.VALIDATION_FAILED,
+                    },
+                  },
+                },
               },
             },
           },

--- a/src/repositories/challenge.repository.js
+++ b/src/repositories/challenge.repository.js
@@ -5,10 +5,23 @@ export class ChallengeRepository {
     this.#prisma = prisma;
   }
 
-  //   async findMany(query) {
-  //   //나중에 pagination 조건넣기
-  //   return await this.#prisma.challenge.findMany();
-  // }
+  // 커서 기반 목록 조회 (무한 스크롤용)
+  async findManyWithCursor({ cursor, skip, take, where, orderBy }) {
+    const args = {
+      where,
+      take,
+      orderBy: orderBy ?? { createdAt: 'desc' },
+    };
+
+    if (cursor && typeof cursor === 'object') {
+      args.cursor = cursor;
+    }
+    if (typeof skip === 'number') {
+      args.skip = skip;
+    }
+
+    return this.#prisma.challenge.findMany(args);
+  }
 
   // 챌린지 관리 : 관리자 페이지와 일반 사용자 페이지에서 모두 사용 가능합니다.
   async findAllChallenges(options) {
@@ -87,9 +100,15 @@ export class ChallengeRepository {
     });
   }
 
-  // 챌린지 생성
   async create(data) {
     return this.#prisma.challenge.create({ data });
+  }
+
+  async update(id, data) {
+    return this.#prisma.challenge.update({
+      where: { id },
+      data,
+    });
   }
 
   // 챌린지 정보 업데이트 (상태 변경, 내용 수정 통합)

--- a/src/repositories/challenge.repository.js
+++ b/src/repositories/challenge.repository.js
@@ -5,7 +5,7 @@ export class ChallengeRepository {
     this.#prisma = prisma;
   }
 
-  // 커서 기반 목록 조회 (무한 스크롤용)
+  // 커서 기반 목록 조회 (무한 스크롤링)
   async findManyWithCursor({ cursor, skip, take, where, orderBy }) {
     const args = {
       where,

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -1,4 +1,5 @@
 import { PRISMA_ERROR, ERROR_MESSAGE, HTTP_STATUS } from '#constants';
+import { getCursorParams, parseCursorResult } from '#utils';
 
 export class ChallengesService {
   #challengeRepository;
@@ -10,7 +11,76 @@ export class ChallengesService {
   }
 
   async listChallenges(query) {
-    return await this.#challengeRepository.findMany(query);
+    const { cursor, limit, status, category, type, keyword } = query;
+
+    const where = {};
+
+    if (status) {
+      where.status = status;
+    }
+
+    if (category) {
+      where.category = category;
+    }
+
+    if (type) {
+      where.type = type;
+    }
+
+    if (keyword && String(keyword).trim() !== '') {
+      where.OR = [
+        {
+          title: {
+            contains: String(keyword).trim(),
+            mode: 'insensitive',
+          },
+        },
+        {
+          description: {
+            contains: String(keyword).trim(),
+            mode: 'insensitive',
+          },
+        },
+      ];
+    }
+
+    const orderBy = { id: 'asc' };
+
+    const {
+      cursor: prismaCursor,
+      skip,
+      take,
+      limit: resolvedLimit,
+    } = getCursorParams({
+      cursor,
+      limit,
+      cursorKey: 'id',
+    });
+
+    const rawItems = await this.#challengeRepository.findManyWithCursor({
+      cursor: prismaCursor,
+      skip,
+      take,
+      where,
+      orderBy,
+    });
+
+    const { items, nextCursor, hasNext } = parseCursorResult({
+      items: rawItems,
+      requestedLimit: resolvedLimit,
+      cursorKey: 'id',
+    });
+
+    return {
+      message: '챌린지 목록 조회 성공',
+      data: {
+        items,
+        pagination: {
+          nextCursor,
+          hasNext,
+        },
+      },
+    };
   }
 
   async getChallengeDetail(id) {

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -1,4 +1,4 @@
-import { PRISMA_ERROR, ERROR_MESSAGE, HTTP_STATUS } from '#constants';
+import { ERROR_MESSAGE, HTTP_STATUS } from '#constants';
 import { getCursorParams, parseCursorResult } from '#utils';
 
 export class ChallengesService {
@@ -13,61 +13,47 @@ export class ChallengesService {
   async listChallenges(query) {
     const { cursor, limit, status, category, type, keyword } = query;
 
-    const where = {};
-
-    if (status) {
-      where.status = status;
-    }
-
-    if (category) {
-      where.category = category;
-    }
-
-    if (type) {
-      where.type = type;
-    }
-
-    if (keyword && String(keyword).trim() !== '') {
-      where.OR = [
-        {
-          title: {
-            contains: String(keyword).trim(),
-            mode: 'insensitive',
+    const where = {
+      ...(status && { status }),
+      ...(category && { category }),
+      ...(type && { type }),
+      ...(keyword && {
+        OR: [
+          {
+            title: {
+              contains: keyword,
+              mode: 'insensitive',
+            },
           },
-        },
-        {
-          description: {
-            contains: String(keyword).trim(),
-            mode: 'insensitive',
+          {
+            description: {
+              contains: keyword,
+              mode: 'insensitive',
+            },
           },
-        },
-      ];
-    }
+        ],
+      }),
+    };
 
     const orderBy = { id: 'asc' };
 
-    const {
-      cursor: prismaCursor,
-      skip,
-      take,
-      limit: resolvedLimit,
-    } = getCursorParams({
+    const paginationParams = getCursorParams({
       cursor,
       limit,
       cursorKey: 'id',
     });
 
     const rawItems = await this.#challengeRepository.findManyWithCursor({
-      cursor: prismaCursor,
-      skip,
-      take,
+      cursor: paginationParams.cursor,
+      skip: paginationParams.skip,
+      take: paginationParams.take,
       where,
       orderBy,
     });
 
     const { items, nextCursor, hasNext } = parseCursorResult({
       items: rawItems,
-      limit: resolvedLimit,
+      limit: paginationParams.limit,
       cursorKey: 'id',
     });
 

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -67,7 +67,7 @@ export class ChallengesService {
 
     const { items, nextCursor, hasNext } = parseCursorResult({
       items: rawItems,
-      requestedLimit: resolvedLimit,
+      limit: resolvedLimit,
       cursorKey: 'id',
     });
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -27,7 +27,7 @@ paths:
       tags: [Admin]
       summary: 챌린지 관리 목록 조회 (승인 대기 챌린지 등)
       security:
-        - bearerAuth: []
+        - accessTokenCookie: []
       parameters:
         - $ref: '#/components/parameters/CursorQuery'
         - $ref: '#/components/parameters/LimitQuery'
@@ -51,8 +51,6 @@ paths:
     get:
       tags: [Admin]
       summary: 특정 챌린지 신청 목록 조회
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/ChallengeIdParam'
         - $ref: '#/components/parameters/CursorQuery'
@@ -75,8 +73,6 @@ paths:
     patch:
       tags: [Admin]
       summary: 신청 승인/거절 (Application 상태 변경)
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/ApplicationIdParam'
       requestBody:
@@ -105,8 +101,6 @@ paths:
     get:
       tags: [Applications]
       summary: 특정 참가 신청 상세 조회
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/ApplicationIdParam'
       responses:
@@ -169,8 +163,6 @@ paths:
     post:
       tags: [Auth]
       summary: 현재 기기 로그아웃
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: 로그아웃 성공
@@ -185,8 +177,6 @@ paths:
     post:
       tags: [Auth]
       summary: 모든 기기 로그아웃
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: 모든 기기 로그아웃 성공
@@ -257,8 +247,6 @@ paths:
     get:
       tags: [Users]
       summary: 내 기본 정보 조회
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: 내 정보 조회 성공
@@ -272,8 +260,6 @@ paths:
     patch:
       tags: [Users]
       summary: 내 기본 정보 수정
-      security:
-        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -297,8 +283,6 @@ paths:
     delete:
       tags: [Users]
       summary: 회원 탈퇴
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: 회원 탈퇴 성공
@@ -333,8 +317,6 @@ paths:
     get:
       tags: [Profile]
       summary: 내 확장 정보 조회
-      security:
-        - bearerAuth: []
       responses:
         '200':
           description: 내 프로필 조회 성공
@@ -350,8 +332,6 @@ paths:
     patch:
       tags: [Profile]
       summary: 내 확장 정보 수정
-      security:
-        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -411,11 +391,6 @@ paths:
           name: keyword
           schema:
             type: string
-        - in: query
-          name: sort
-          schema:
-            type: string
-            example: latest
       responses:
         '200':
           description: 챌린지 목록 조회 성공
@@ -429,8 +404,6 @@ paths:
     post:
       tags: [Challenges]
       summary: 새 챌린지 생성
-      security:
-        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -453,8 +426,6 @@ paths:
     get:
       tags: [Challenges]
       summary: 내가 신청한 챌린지 목록 조회
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/CursorQuery'
         - $ref: '#/components/parameters/LimitQuery'
@@ -493,8 +464,6 @@ paths:
     patch:
       tags: [Challenges]
       summary: 특정 챌린지 정보 수정
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/ChallengeIdParam'
       requestBody:
@@ -524,8 +493,6 @@ paths:
     delete:
       tags: [Challenges]
       summary: 특정 챌린지 삭제
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/ChallengeIdParam'
       responses:
@@ -546,8 +513,6 @@ paths:
     get:
       tags: [Challenges]
       summary: 내가 만든 챌린지 목록 조회
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/CursorQuery'
         - $ref: '#/components/parameters/LimitQuery'
@@ -569,8 +534,6 @@ paths:
     get:
       tags: [Challenges]
       summary: 내가 신청한 특정 챌린지 상세 조회
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/ChallengeIdParam'
       responses:
@@ -590,8 +553,6 @@ paths:
     patch:
       tags: [Challenges]
       summary: 챌린지 신청 취소 (삭제 대신 상태 변경)
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/ChallengeIdParam'
       requestBody:
@@ -636,8 +597,6 @@ paths:
     post:
       tags: [Applications]
       summary: 챌린지 신청
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/ChallengeIdParam'
       requestBody:
@@ -689,8 +648,6 @@ paths:
     post:
       tags: [Works]
       summary: 작업물 등록
-      security:
-        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -732,8 +689,6 @@ paths:
     patch:
       tags: [Works]
       summary: 작업물 수정
-      security:
-        - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/WorkIdParam'
       requestBody:
@@ -1048,10 +1003,11 @@ paths:
 
 components:
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+    accessTokenCookie:
+      type: apiKey
+      in: cookie
+      name: accessToken
+      description: 로그인 시 발급되는 Access Token 쿠키
 
   parameters:
     ProviderParam:
@@ -1116,6 +1072,7 @@ components:
       required: false
       schema:
         type: string
+        description: 다음 페이지 조회를 위한 커서(ULID)
 
     LimitQuery:
       in: query
@@ -1124,8 +1081,8 @@ components:
       schema:
         type: integer
         minimum: 1
-        maximum: 50
-        default: 10
+        maximum: 100
+        default: 20
 
   responses:
     BadRequest:
@@ -1134,6 +1091,10 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
+          example:
+            message: 잘못된 요청입니다.
+            code: BAD_REQUEST
+            details: null
 
     Unauthorized:
       description: 인증 실패
@@ -1141,6 +1102,10 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
+          example:
+            message: 인증이 필요합니다.
+            code: UNAUTHORIZED
+            details: null
 
     Forbidden:
       description: 권한 없음
@@ -1148,6 +1113,10 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
+          example:
+            message: 접근 권한이 없습니다.
+            code: FORBIDDEN
+            details: null
 
     NotFound:
       description: 리소스를 찾을 수 없음
@@ -1155,6 +1124,10 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
+          example:
+            message: 리소스를 찾을 수 없습니다.
+            code: RESOURCE_NOT_FOUND
+            details: null
 
     Conflict:
       description: 충돌 발생
@@ -1162,6 +1135,10 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
+          example:
+            message: 이미 존재하는 리소스입니다.
+            code: RESOURCE_CONFLICT
+            details: null
 
   schemas:
     Role:
@@ -1233,13 +1210,14 @@ components:
       properties:
         message:
           type: string
-          example: 잘못된 요청입니다.
+          description: 에러 메시지
         code:
           type: string
-          example: BAD_REQUEST
+          description: 에러 코드
         details:
           type: object
           nullable: true
+          description: 필드별 에러 상세 정보 (검증 실패 등)
 
     Pagination:
       type: object


### PR DESCRIPTION
## 🔧 작업 내용 요약

- 페이지네이션 유틸 추가
  - cursor: 무한 스크롤링, 더보기에 사용
  - offset: 페이지 번호 기반 페이지네이션에 사용
- Challenge 전체 목록 조회 API -> Cursor 기반으로 API 구현 및 테스트 완료

## 📣 팀원들에게 공유할 내용 / 도움 요청
- 공용으로 사용할 offset, cursor 기반 페이지네이션 유틸을 제작했습니다.
- 담당 파트에 페이지네이션이 있으신 경우, 사용하시면 됩니다.
- challenge 목록에 cursor 기반 페이지네이션을 적용시켜놨으니, 사용법 예시로 보시면 좋겠습니다.
<!-- 새로 설치한 패키지 등 팀과 공유 해야 할 내용 -->
<!-- 도움 및 리뷰가 필요한 부분이 있다면 공유 -->

## 🔗 관련 이슈
#6 
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
<!-- 여기에 " closes #이슈번호 " 를 적으면 이슈가 자동으로 종료됩니다 -->